### PR TITLE
Add ability to include plugins on Jobs

### DIFF
--- a/lib/Resque/Job/Performer.php
+++ b/lib/Resque/Job/Performer.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Resque job performer.
+ *
+ * @package        Resque/Job
+ * @author        Protec Innovations <dev@protecinnovations.co.uk>
+ * @license        http://www.opensource.org/licenses/mit-license.php
+ */
+class Resque_Job_Performer
+{
+    const HOOKS_AFTER = 'after';
+    const HOOKS_AROUND = 'around';
+    const HOOKS_BEFORE = 'before';
+
+    /**
+     * @var object $job
+     */
+    private $job;
+
+    /**
+     * @var array $args
+     */
+    private $args;
+
+    /**
+     * @var array $hooks
+     */
+    private $hooks;
+
+    /**
+     * @var bool $performed
+     */
+    private $performed = false;
+
+    /**
+     * Resque_Job_Performer constructor.
+     *
+     * @param object $job
+     * @param array $args
+     * @param array $hooks
+     */
+    public function __construct($job, array $args, array $hooks)
+    {
+        $this->job = $job;
+        $this->args = $args;
+        $this->hooks = $hooks;
+    }
+
+    /**
+     * perform
+     *
+     * @return bool
+     */
+    public function perform()
+    {
+        $this->callBeforeHooks();
+
+        $this->executeJob();
+
+        $this->callHooks(self::HOOKS_AFTER);
+
+        return $this->performed;
+    }
+
+    /**
+     * callBeforeHooks
+     *
+     */
+    protected function callBeforeHooks()
+    {
+        $this->callHooks(self::HOOKS_BEFORE);
+    }
+
+    /**
+     * callHooks
+     *
+     * @param string $hook_type
+     */
+    protected function callHooks($hook_type)
+    {
+        foreach ($this->hooks[$hook_type] as $hook) {
+            $this->performHook($hook);
+        }
+    }
+
+    /**
+     * performHook
+     *
+     * @param string $hook
+     */
+    protected function performHook($hook)
+    {
+        call_user_func_array([$this->job, $hook], $this->args);
+    }
+
+    /**
+     * executeJob
+     *
+     */
+    protected function executeJob()
+    {
+        if (empty($this->hooks[self::HOOKS_AROUND])) {
+            $this->performJob();
+        } else {
+            $this->callAroundHooks();
+        }
+    }
+
+    /**
+     * callAroundHooks
+     *
+     */
+    protected function callAroundHooks()
+    {
+        $hooks = $this->nestedAroundHooks();
+
+        $hooks();
+    }
+
+    /**
+     * nestedAroundHooks
+     *
+     * @return Closure
+     */
+    protected function nestedAroundHooks()
+    {
+        $final_hook = [$this, 'performJob'];
+
+        $around_hooks = array_reverse($this->hooks[self::HOOKS_AROUND]);
+
+        $args = $this->args;
+
+        $job = $this->job;
+
+        return array_reduce(
+            $around_hooks,
+            function ($last_hook, $hook) use ($args, $job) {
+                $callback = [$job, $hook];
+                return function() use ($callback, $last_hook, $args) {
+                    call_user_func_array($callback, [$args, $last_hook]);
+                };
+            },
+            $final_hook
+        );
+    }
+
+    /**
+     * performJob
+     *
+     * @return mixed
+     */
+    public function performJob()
+    {
+        $result = $this->job->perform($this->args);
+        $this->performed = true;
+        return $result;
+    }
+}

--- a/lib/Resque/Plugin.php
+++ b/lib/Resque/Plugin.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Plugin
+ *
+ * @package Resque
+ * @author Protec Innovations <support@protecinnovations.co.uk>
+ * @license http://www.opensource.org/licenses/mit-license.php
+ */
+class Resque_Plugin
+{
+    const PREFIX_BEFORE_PERFORM = 'beforePerform';
+    const PREFIX_AFTER_PERFORM = 'afterPerform';
+    const PREFIX_AROUND_PERFORM = 'aroundPerform';
+
+    /**
+     * beforeHooks
+     *
+     * @param object $job
+     *
+     * @return array
+     */
+    public static function beforeHooks($job)
+    {
+        return self::getMethodsWithPrefix($job, self::PREFIX_BEFORE_PERFORM);
+    }
+
+    /**
+     * afterHooks
+     *
+     * @param object $job
+     *
+     * @return array
+     */
+    public static function afterHooks($job)
+    {
+        return self::getMethodsWithPrefix($job, self::PREFIX_AFTER_PERFORM);
+    }
+
+    /**
+     * aroundHooks
+     *
+     * @param object $job
+     *
+     * @return array
+     */
+    public static function aroundHooks($job)
+    {
+        return self::getMethodsWithPrefix($job, self::PREFIX_AROUND_PERFORM);
+    }
+
+    /**
+     * getMethodsWithPrefix
+     *
+     * @param object $class
+     * @param string $prefix
+     *
+     * @return array
+     */
+    protected static function getMethodsWithPrefix($class, $prefix)
+    {
+        $reflection = new ReflectionClass($class);
+
+        $has_basic_hook = false;
+
+        $return = [];
+
+        foreach ($reflection->getMethods() as $method) {
+            $method_name = $method->getName();
+
+            if (substr($method_name, 0, strlen($prefix)) == $prefix) {
+                if (strlen($prefix) == strlen($method_name)) {
+                    $has_basic_hook = true;
+                } else {
+                    $return[] = $method_name;
+                }
+            }
+        }
+
+        // Make sure we add the "basic" one last
+        if ($has_basic_hook) {
+            $return[] = $prefix;
+        }
+
+        return $return;
+    }
+}


### PR DESCRIPTION
Add the ability to include plugins on the job themselves.

This currently only implements the `beforePerform`/`afterPerform`/`aroundPerform` plugins